### PR TITLE
Do not run updates_vars.py on remote host

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -11,7 +11,7 @@ ssh_key: "REPLACE_SSH_PUBLIC_KEY"
 
 # For VMs created from cloud UI - block_storage: "/dev/vdb"
 # For VMs created from terraform - block_storage: "/dev/vdd"
-block_storage: "/dev/vdb"
+block_storage: "/dev/vdd"
 
 delay: 5
 retries: 5

--- a/ansible/roles/install_packages_locally/tasks/main.yml
+++ b/ansible/roles/install_packages_locally/tasks/main.yml
@@ -9,6 +9,6 @@
 - name: Run a script using an executable in a system path
   script: ./update_vars.py
   args:
-    executable: python3
+    executable: python
   ignore_errors: true
 

--- a/ansible/roles/prepare_host/tasks/initial_install.yaml
+++ b/ansible/roles/prepare_host/tasks/initial_install.yaml
@@ -1,9 +1,3 @@
-- name: Run a script using an executable in a system path
-  script: ./update_vars.py
-  args:
-    executable: python3
-  ignore_errors: true
-
 - name: Update and upgrade apt packages
   become: true
   apt:


### PR DESCRIPTION
Do not run updates_vars.py on remote host, set default block storage to /dev/vdd and use python instead of specific version.